### PR TITLE
Updates parsing for eventType and adding challenge verification

### DIFF
--- a/netlify/functions/twitch-subscription.js
+++ b/netlify/functions/twitch-subscription.js
@@ -4,6 +4,14 @@ exports.handler = async (event) => {
 
     const type = headers['twitch-eventsub-message-type'] || 'no type';
     const eventType = JSON.parse(event.body).subscription.type;
+    
+    if (type == "webhook_callback_verification") {
+      return {
+        statusCode: 200,
+        headers: { "content-type": "text/plain" },
+        body: JSON.parse(event.body).challenge,
+      };
+    }
 
 
     if(type !== 'notification' || eventType !== 'channel.follow') {

--- a/netlify/functions/twitch-subscription.js
+++ b/netlify/functions/twitch-subscription.js
@@ -3,10 +3,10 @@ exports.handler = async (event) => {
     const { headers } = event;
 
     const type = headers['twitch-eventsub-message-type'] || 'no type';
-    const eventType = headers['twitch-eventsub-subscription-type'];
+    const eventType = JSON.parse(event.body).subscription.type;
 
 
-    if(type !== 'notification' || eventType!== 'channel.follow') {
+    if(type !== 'notification' || eventType !== 'channel.follow') {
         return { statusCode: 200, body: ''};
     }
 


### PR DESCRIPTION
## Summary

I was investigating your code and was VERY perplexed why it wasn't working. I have a suspicion what used to work with the APIs during the LWJ show might be slightly different. Instead of using the headers to determine the type we're handling, we can retrieve that from the body of the POST request that is being made by Twitch.

In addition to that, I didn't see your code for the challenge verification. That part we might have not done but is necessary for the subscription to be fully set. 

### Technical Details

In the [documentation](https://dev.twitch.tv/docs/eventsub/handling-webhook-events#processing-an-event) for Twitch they use the headers to process the message type but then the body to process the subscription type. So we'll need to use the body that has a shape like:

```js
{
  "subscription": {
    "id": "f1c2a387-161a-49f9-a165-0f21d7a4e1c4",
    "status": "enabled",
    "type": "channel.follow", // <--- And this is the key we'd need to operate on!
    "version": "1",
    "cost": 1,
    "condition": {
      "broadcaster_user_id": "12826"
    },
    "transport": {
      "method": "webhook",
      "callback": "https://example.com/webhooks/callback"
    },
    "created_at": "2019-11-16T10:11:12.123Z"
  },
  "event": {
    "user_id": "1337",
    "user_login": "awesome_user",
    "user_name": "Awesome_User",
    "broadcaster_user_id":     "12826",
    "broadcaster_user_login":  "twitch",
    "broadcaster_user_name":   "Twitch"
  }
}
```

Once I did that it seemed to all be working for ya!

Before you can use the webhook, you need to be certain it is verified, for the most part that means echoing back the challenge key that they give you upon the POST request you receive. That is what this would do:

```js
  if (type == "webhook_callback_verification") {
    return {
      statusCode: 200,
      headers: { "content-type": "text/plain" },
      body: JSON.parse(event.body).challenge,
    };
  }
```

Be certain that your secret is also at least 10 characters! Technically you should be doing a bit more like it says in the [documentation](https://dev.twitch.tv/docs/eventsub/handling-webhook-events#verifying-the-event-message) like checking against your secret but 🤷🏾. Definitely focus on getting it live!

## Extra Resources

I know in the Learn with Jason episode I may have referred to the [Twitch CLI](https://github.com/twitchdev/twitch-cli) and I still recommend using it! I was able to test your code with it and the Netlify CLI!

When I ran this command while my Netlify Dev server was running (in another shell having `ntl dev`):

```
twitch event trigger channel.follow -F http://localhost:8888/.netlify/functions/twitch-subscription
``` 

The Twitch CLI has a command called `event` which will allow you to mock out different event types you could receive. If we want to test our `channel.follow` events we need to make sure to `trigger` them. The `-F http://localhost:8888/.netlify/functions/twitch-subscription` allows us to set what URL we want to mock against.

And you can also test your verification step with this:

```
twitch event verify-subscription subscribe -F http://localhost:8888/.netlify/functions/twitch-subscription
```

Similar to `event trigger channel.follow` this `event verify-subscription subscribe` is mocking the verification step that we need to do before a EventSub is triggerable. 
